### PR TITLE
Fix: Add Vercel configuration for build process.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a `vercel.json` file to the project root to provide explicit build instructions for the Vercel deployment platform.

The previous deployment was failing with 404 errors because Vercel was not running the necessary build step (`npm run build`) and was attempting to serve the raw source code from the `src` directory.

The new `vercel.json` file instructs Vercel to:
1.  Recognize the project as a static build application.
2.  Run the `"build"` script defined in `package.json`.
3.  Deploy the output from the `dist` directory.

This ensures that the Vite build process is executed correctly, and the final, optimized site is deployed, resolving the 404 errors.